### PR TITLE
show actual recurrence params in editevent views (issue #627)

### DIFF
--- a/admin/language/en-GB/en-GB.com_jem.ini
+++ b/admin/language/en-GB/en-GB.com_jem.ini
@@ -531,6 +531,7 @@ COM_JEM_OUTPUT_MONTH="repeating every [placeholder] month"
 COM_JEM_OUTPUT_WEEKDAY="repeating every [placeholder]. [placeholder_weekday] per month"
 COM_JEM_RECURRENCE_COUNTER="By the end of"
 COM_JEM_UNLIMITED="unlimited"
+COM_JEM_RECURRING_INFO_TITLE="Current recurrence settings (informational)"
 
 COM_JEM_LAST=" last"
 COM_JEM_BEFORE_LAST=" before last"

--- a/admin/views/event/tmpl/edit.php
+++ b/admin/views/event/tmpl/edit.php
@@ -412,6 +412,76 @@ $params = $params->toArray();
 			</script>
 		</fieldset>
 
+		<?php /* show "old" recurrence settings for information */
+		if (!empty($this->item->recurr_bak->recurrence_type)) {
+			$recurr_type = '';
+			$recurr_limit_date = str_ireplace('0000-00-00', JText::_('COM_JEM_UNLIMITED'),
+			                                  $this->item->recurr_bak->recurrence_limit_date);
+
+			switch ($this->item->recurr_bak->recurrence_type) {
+			case 1: 
+				$recurr_type = JText::_('COM_JEM_DAYLY');
+				$recurr_info = str_ireplace('[placeholder]',
+				                            $this->item->recurr_bak->recurrence_number,
+				                            JText::_('COM_JEM_OUTPUT_DAY'));
+				break;
+			case 2:
+				$recurr_type = JText::_('COM_JEM_WEEKLY');
+				$recurr_info = str_ireplace('[placeholder]',
+				                            $this->item->recurr_bak->recurrence_number,
+				                            JText::_('COM_JEM_OUTPUT_WEEK'));
+				break;
+			case 3:
+				$recurr_type = JText::_('COM_JEM_MONTHLY');
+				$recurr_info = str_ireplace('[placeholder]',
+				                            $this->item->recurr_bak->recurrence_number,
+				                            JText::_('COM_JEM_OUTPUT_MONTH'));
+				break;
+			case 4:
+				$recurr_type = JText::_('COM_JEM_WEEKDAY');
+				$recurr_byday = preg_replace('/(,)([^ ,]+)/', '$1 $2', $this->item->recurr_bak->recurrence_byday);
+				$recurr_days = str_ireplace(array('MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SO'),
+				                            array(JText::_('COM_JEM_MONDAY'), JText::_('COM_JEM_TUESDAY'),
+				                                  JText::_('COM_JEM_WEDNESDAY'), JText::_('COM_JEM_THURSDAY'),
+				                                  JText::_('COM_JEM_FRIDAY'), JText::_('COM_JEM_SATURDAY'),
+				                                  JText::_('COM_JEM_SUNDAY')),
+				                            $recurr_byday);
+				$recurr_num  = str_ireplace(array('5', '6'),
+				                            array(JText::_('COM_JEM_LAST'), JText::_('COM_JEM_BEFORE_LAST')),
+				                            $this->item->recurr_bak->recurrence_number);
+				$recurr_info = str_ireplace(array('[placeholder]', '[placeholder_weekday]'),
+				                            array($recurr_num, $recurr_days),
+				                            JText::_('COM_JEM_OUTPUT_WEEKDAY'));
+				break;
+			default:
+				break;
+			}
+
+			if (!empty($recurr_type)) {
+		 ?>
+				<hr>
+				<fieldset class="panelform">
+					<p><strong><?php echo JText::_('COM_JEM_RECURRING_INFO_TITLE'); ?></strong></p>
+					<ul>
+						<li>
+							<label><?php echo JText::_('COM_JEM_RECURRENCE'); ?></label>
+							<input type="text" class="readonly" readonly="readonly" value="<?php echo $recurr_type; ?>">
+						</li>
+						<li>
+							<div class="clear"></div>
+							<label> </label>
+							<?php echo $recurr_info; ?>
+						</li>
+						<li>
+							<label><?php echo JText::_('COM_JEM_RECURRENCE_COUNTER'); ?></label>
+							<input type="text" class="readonly" readonly="readonly" value="<?php echo $recurr_limit_date; ?>">
+						</li>
+					</ul>
+				</fieldset>
+		<?php
+			}
+		} ?>
+
 		<!-- START OF PANEL META -->
 		<?php echo JHtml::_('sliders.panel', JText::_('COM_JEM_METADATA_INFORMATION'), 'meta-event'); ?>
 

--- a/site/language/en-GB/en-GB.com_jem.ini
+++ b/site/language/en-GB/en-GB.com_jem.ini
@@ -199,6 +199,7 @@ COM_JEM_OUTPUT_MONTH="repeating every [placeholder] month"
 COM_JEM_OUTPUT_WEEKDAY="repeating every [placeholder]. [placeholder_weekday] per month"
 COM_JEM_RECURRENCE_COUNTER="By the end of"
 COM_JEM_UNLIMITED="unlimited"
+COM_JEM_RECURRING_INFO_TITLE="Current recurrence settings (informational)"
 
 COM_JEM_LAST=" last"
 COM_JEM_BEFORE_LAST=" before last"

--- a/site/views/editevent/tmpl/edit_other.php
+++ b/site/views/editevent/tmpl/edit_other.php
@@ -99,4 +99,72 @@ defined('_JEXEC') or die;
 			start_recurrencescript("jform_recurrence_type");
 		-->
 		</script>
+
+		<?php /* show "old" recurrence settings for information */
+		if (!empty($this->item->recurr_bak->recurrence_type)) {
+			$recurr_type = '';
+			$recurr_limit_date = str_ireplace('0000-00-00', JText::_('COM_JEM_UNLIMITED'),
+			                                  $this->item->recurr_bak->recurrence_limit_date);
+
+			switch ($this->item->recurr_bak->recurrence_type) {
+			case 1: 
+				$recurr_type = JText::_('COM_JEM_DAYLY');
+				$recurr_info = str_ireplace('[placeholder]',
+				                            $this->item->recurr_bak->recurrence_number,
+				                            JText::_('COM_JEM_OUTPUT_DAY'));
+				break;
+			case 2:
+				$recurr_type = JText::_('COM_JEM_WEEKLY');
+				$recurr_info = str_ireplace('[placeholder]',
+				                            $this->item->recurr_bak->recurrence_number,
+				                            JText::_('COM_JEM_OUTPUT_WEEK'));
+				break;
+			case 3:
+				$recurr_type = JText::_('COM_JEM_MONTHLY');
+				$recurr_info = str_ireplace('[placeholder]',
+				                            $this->item->recurr_bak->recurrence_number,
+				                            JText::_('COM_JEM_OUTPUT_MONTH'));
+				break;
+			case 4:
+				$recurr_type = JText::_('COM_JEM_WEEKDAY');
+				$recurr_byday = preg_replace('/(,)([^ ,]+)/', '$1 $2', $this->item->recurr_bak->recurrence_byday);
+				$recurr_days = str_ireplace(array('MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SO'),
+				                            array(JText::_('COM_JEM_MONDAY'), JText::_('COM_JEM_TUESDAY'),
+				                                  JText::_('COM_JEM_WEDNESDAY'), JText::_('COM_JEM_THURSDAY'),
+				                                  JText::_('COM_JEM_FRIDAY'), JText::_('COM_JEM_SATURDAY'),
+				                                  JText::_('COM_JEM_SUNDAY')),
+				                            $recurr_byday);
+				$recurr_num  = str_ireplace(array('5', '6'),
+				                            array(JText::_('COM_JEM_LAST'), JText::_('COM_JEM_BEFORE_LAST')),
+				                            $this->item->recurr_bak->recurrence_number);
+				$recurr_info = str_ireplace(array('[placeholder]', '[placeholder_weekday]'),
+				                            array($recurr_num, $recurr_days),
+				                            JText::_('COM_JEM_OUTPUT_WEEKDAY'));
+				break;
+			default:
+				break;
+			}
+
+			if (!empty($recurr_type)) {
+		 ?>
+				<hr>
+				<p><strong><?php echo JText::_('COM_JEM_RECURRING_INFO_TITLE'); ?></strong></p>
+				<ul class="adminformlist">
+					<li>
+						<label><?php echo JText::_('COM_JEM_RECURRENCE'); ?></label>
+						<input type="text" class="readonly" readonly="readonly" value="<?php echo $recurr_type; ?>">
+					</li>
+					<li>
+						<div class="clear"></div>
+						<label> </label>
+						<?php echo $recurr_info; ?>
+					</li>
+					<li>
+						<label><?php echo JText::_('COM_JEM_RECURRENCE_COUNTER'); ?></label>
+						<input type="text" class="readonly" readonly="readonly" value="<?php echo $recurr_limit_date; ?>">
+					</li>
+				</ul>
+		<?php
+			}
+		} ?>
 	</fieldset>


### PR DESCRIPTION
This will show actual recurrence settings (if recurring event) in editevent views on frontend and backend.
Please take a look and decide if it should become part of 1.9.6.
