### PR TITLE
Improved mailer plugin & email by category v2

### DIFF
--- a/admin/language/en-GB/en-GB.com_jem.ini
+++ b/admin/language/en-GB/en-GB.com_jem.ini
@@ -36,6 +36,10 @@ COM_JEM_CATEGORY_FIELD_PARENT_DESC="Select a Parent Category"
 COM_JEM_CATEGORY_FIELD_PARENT_LABEL="Parent"
 COM_JEM_CATEGORY_FIELDSET_DETAILS="Details"
 COM_JEM_CATEGORY_NO_GROUP="No Group"
+COM_JEM_CATEGORY_FIELDSET_EMAIL="Category emails"
+COM_JEM_CATEGORY_FIELDSET_EMAIL_DESC="Notification this category by email(s)"
+COM_JEM_CATEGORY_INPUT_EMAIL="Email(s)"
+COM_JEM_CATEGORY_INPUT_EMAIL_DESC="Email addresses, comma separated, to which you can send a mail on event creation or edition."
 
 ; CATEGORIES-View
 COM_JEM_CATEGORIES_DELETE_NOT_ALLOWED="Delete not allowed for category %s. "

--- a/admin/models/forms/category.xml
+++ b/admin/models/forms/category.xml
@@ -113,6 +113,15 @@
 		/>
 	</fieldset>
 
+	<fieldset name="confemail" label="COM_JEM_CATEGORY_FIELDSET_EMAIL">
+		<field name="email" type="text"
+			size="20"
+			readonly="false"
+			class="inputbox"
+			label="COM_JEM_CATEGORY_INPUT_EMAIL"
+		/>
+	</fieldset>
+
 	<fieldset name="image"
 		label="COM_JEM_IMAGE"
 	>

--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -123,6 +123,7 @@ CREATE TABLE IF NOT EXISTS `#__jem_categories` (
   `metadata` varchar(2048) NOT NULL,
   `modified_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `modified_user_id` int(10) unsigned NOT NULL DEFAULT '0',
+  `email` varchar(200) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM CHARACTER SET `utf8` COLLATE `utf8_general_ci`;
 

--- a/admin/sql/updates/1.9.6.sql
+++ b/admin/sql/updates/1.9.6.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `#__jem_categories`
+	ADD email varchar(200) NOT NULL DEFAULT '';

--- a/admin/views/category/tmpl/edit.php
+++ b/admin/views/category/tmpl/edit.php
@@ -75,6 +75,16 @@ JHtml::_('behavior.keepalive');
 			<?php echo $this->loadTemplate('options'); ?>
 			<div class="clr"></div>
 
+			<?php echo JHtml::_('sliders.panel', JText::_('COM_JEM_CATEGORY_FIELDSET_EMAIL'), 'confemail'); ?>
+			<fieldset class="panelform">
+				<ul class="adminformlist">
+					<li>
+						<?php echo $this->form->getLabel('email'); ?>
+						<?php echo $this->form->getInput('email'); ?>
+					</li>
+				</ul>
+			</fieldset>
+
 			<?php echo JHtml::_('sliders.panel', JText::_('COM_JEM_GROUP'), 'group'); ?>
 			<fieldset class="panelform">
 				<ul class="adminformlist">

--- a/plugins/plg_jem_mailer/language/en-GB/en-GB.plg_jem_mailer.ini
+++ b/plugins/plg_jem_mailer/language/en-GB/en-GB.plg_jem_mailer.ini
@@ -11,39 +11,50 @@
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 PLG_JEM_MAILER_PLUGIN_DESC="Send an email to the user and/or admins if someone registers or unregisters from an event."
-PLG_JEM_MAILER_USER_REG="Email user on registration"
+
+; Plugin options
+
+PLG_JEM_MAILER_USER_NOTIFICATIONS="Registration notifications"
 PLG_JEM_MAILER_USER_REG_DESC="Decide whether or not the user should receive a confirmation email of their registration."
-PLG_JEM_MAILER_ADMIN_REG="Email admin on registration"
-PLG_JEM_MAILER_ADMIN_REG_DESC="Decide whether or not site administrators should receive a confirmation email when a user registers for an event. You need to enter the email addresses you want to receive the confirmation messages here in the 'Admin email recipients' field below."
-PLG_JEM_MAILER_SETTINGS_USER_REG_ONOFF="Email user on waiting list on/off"
+PLG_JEM_MAILER_ADMIN_REG_DESC="Decide whether or not site administrators should receive a confirmation email when a user registers for an event. You need to enter the email addresses you want to receive the confirmation messages here in the 'Distribution list' field below."
 PLG_JEM_MAILER_SETTINGS_USER_REG_ONOFF_DESC="Decide whether or not the user should receive a email when he is taken on/off an event waiting list."
-PLG_JEM_MAILER_SETTINGS_ADMIN_REG_ONOFF="Email admin on waiting list on/off"
-PLG_JEM_MAILER_SETTINGS_ADMIN_REG_ONOFF_DESC="Decide whether or not site administrators should receive a confirmation email when a user is taken on or off an event waiting list. You need to enter the email addresses you want to receive the confirmation messages here in the 'Admin email recipients' field below."
-PLG_JEM_MAILER_USER_UNREG="Email user on unregistration"
+PLG_JEM_MAILER_SETTINGS_ADMIN_REG_ONOFF_DESC="Decide whether or not site administrators should receive a confirmation email when a user is taken on or off an event waiting list. You need to enter the email addresses you want to receive the confirmation messages here in the 'Distribution list' field below."
 PLG_JEM_MAILER_USER_UNREG_DESC="Decide whether or not the user should receive a confirmation email after unregistering for an event."
-PLG_JEM_MAILER_ADMIN_UNREG="Email admin on unregistration"
-PLG_JEM_MAILER_ADMIN_UNREG_DESC="Decide whether or not site administrators should receive a confirmation email when a user unregisters for an event. You need to enter the email addresses you want to receive the confirmation messages here in the 'Admin email recipients' field below. "
-PLG_JEM_MAILER_USER_NEW_EVENT="Email user on new event submission"
+PLG_JEM_MAILER_ADMIN_UNREG_DESC="Decide whether or not site administrators should receive a confirmation email when a user unregisters for an event. You need to enter the email addresses you want to receive the confirmation messages here in the 'Distribution list' field below. "
+PLG_JEM_MAILER_REGISTRATION="Registration email to:"
+PLG_JEM_MAILER_WAITINGLIST="Waitinglist on/off email to:"
+PLG_JEM_MAILER_UNREGISTRATION="Unregistration email to:"
+PLG_JEM_MAILER_EVENT_NOTIFICATIONS="Event notifications"
+PLG_JEM_MAILER_NEW_EVENT_TITLE="Email on new event to"
+PLG_JEM_MAILER_EDIT_EVENT_TITLE="Email on update event to:"
+PLG_JEM_MAILER_USER_LABEL="User"
 PLG_JEM_MAILER_USER_NEW_EVENT_DESC="Decide whether or not the user should receive a confirmation email of their event submission."
+PLG_JEM_MAILER_ADMIN_LABEL="Admin"
 PLG_JEM_MAILER_ADMIN_NEW_EVENT="Email administrators on new event submission"
-PLG_JEM_MAILER_ADMIN_NEW_EVENT_DESC="Decide whether or not the administrators should receive a confirmation email of a new event submission."
-PLG_JEM_MAILER_USER_EDIT_EVENT="Email user on edit event action"
 PLG_JEM_MAILER_USER_EDIT_EVENT_DESC="Decide whether or not the user should receive a confirmation email of their edit event action."
-PLG_JEM_MAILER_ADMIN_EDIT_EVENT="Email administrators on edit event action"
 PLG_JEM_MAILER_ADMIN_EDIT_EVENT_DESC="Decide whether or not the administrators should receive a confirmation email of the edit event action."
-PLG_JEM_MAILER_USER_NEW_VENUE="Email user on new venue submission"
+PLG_JEM_MAILER_REGISTERED_EDIT_EVENT="Registered"
+PLG_JEM_MAILER_REGISTERED_EDIT_EVENT_DESC="Decide whether or not users registered and on waiting list of an event should recieve an email on an edit of that event."
+
+PLG_JEM_MAILER_CATEGORY_LABEL="Category"
+PLG_JEM_MAILER_NOTIFY_CATEGORY_DESC="Enable the send of emails to the addresses designated in the category 'email' field when events are created or edited."
+
+PLG_JEM_MAILER_GROUP_LABEL="Group"
+PLG_JEM_MAILER_NEW_EVENT_GROUP="Decide whether users group of the category of the event receive emails when creating a new event in this category"
+PLG_JEM_MAILER_EDIT_EVENT_GROUP="Decide whether users group of the category of the event receive emails when a new event is published in this category"
+
+PLG_JEM_MAILER_VENUE_NOTIFICATIONS="Venue Notifications"
+PLG_JEM_MAILER_NEW_VENUE_TITLE="Email on new venue to:"
+PLG_JEM_MAILER_EDIT_VENUE_TITLE="Email on update venue to:"
 PLG_JEM_MAILER_USER_NEW_VENUE_DESC="Decide whether or not the user should receive a confirmation email of their venue submission."
-PLG_JEM_MAILER_ADMIN_NEW_VENUE="Email administrators on new venue submission"
 PLG_JEM_MAILER_ADMIN_NEW_VENUE_DESC="Decide whether or not the administrators should receive a confirmation email of a new venue submission."
-PLG_JEM_MAILER_USER_EDIT_VENUE="Email user on edit venue action"
 PLG_JEM_MAILER_USER_EDIT_VENUE_DESC="Decide whether or not the user should receive a confirmation email of their edit venue action."
-PLG_JEM_MAILER_ADMIN_EDIT_VENUE="Email administrators on edit venue action"
 PLG_JEM_MAILER_ADMIN_EDIT_VENUE_DESC="Decide whether or not the administrators should receive a confirmation email of the edit venue action."
 
-PLG_JEM_MAILER_ALL_ADMINS="Mail all System Mail receivers"
+PLG_JEM_MAILER_ADMIN_OPTIONS="Administrators"
 PLG_JEM_MAILER_ALL_ADMINS_DESC="Decide whether or not the administrators who are allowed to receive System Emails should receive admin confirmation mails."
-PLG_JEM_MAILER_ADDITIONAL_MAIL_RECEIVERS="Admin email recipients"
-PLG_JEM_MAILER_ADDITIONAL_MAIL_RECEIVERS_DESC="The email addresses of people who should receive the admin confirmation emails. They must be separated with a comma. This list will be work independant to the above option but works also fine together."
+PLG_JEM_MAILER_ADMIN_MAIL_RECEIVERS="Distribution list"
+PLG_JEM_MAILER_ADMIN_MAIL_RECEIVERS_DESC="The email addresses of people who should receive the admin confirmation emails. They must be separated with a comma. This list will be work independant to the above option but works also fine together."
 
 ; Register mailtexts 
 PLG_JEM_MAILER_USER_REG_SUBJECT="%s: Event Registration Successful"
@@ -76,6 +87,7 @@ PLG_JEM_MAILER_EDIT_EVENT_MAIL=" %s : Edited Event"
 PLG_JEM_MAILER_EDIT_EVENT="An Event was edited from %s ( %s ) \n\nMailadress: %s \nIP: %s \nModified at: %s \n\nTitle: %s \nDate: %s \nTime: %s \nVenue: %s / %s \n\nDescription:\n%s \n\n%s"
 PLG_JEM_MAILER_EVENT_PUBLISHED="The Event is published and can be viewed by clicking this link: %s"
 PLG_JEM_MAILER_EVENT_UNPUBLISHED="The Event is unpublished and needs to be reviewed"
+PLG_JEM_MAILER_EVENT_TRASHED="The Event has been deleted"
 
 PLG_JEM_MAILER_NEW_VENUE_MAIL=" %s : New Venue"
 PLG_JEM_MAILER_NEW_VENUE="You received a new submission from %s ( %s ) \n\nMailadress: %s \nIP: %s \nSubmission time: %s \n\nName: %s \nWebsite: %s \nStreet: %s \nZIP: %s \nCity: %s \nCountry: %s \n\nDescription:\n%s \n\n%s"
@@ -83,6 +95,11 @@ PLG_JEM_MAILER_EDIT_VENUE_MAIL=" %s : Edited Venue"
 PLG_JEM_MAILER_EDIT_VENUE="A Venue was edited from %s ( %s ) \n\nMailadress: %s \nIP: %s \nModified at: %s \n\nName: %s \nWebsite: %s \nStreet: %s \nZIP: %s \nCity: %s \nCountry: %s \n\nDescription:\n%s \n\n%s"
 PLG_JEM_MAILER_VENUE_PUBLISHED="The Venue is published and can be viewed by clicking this link: %s"
 PLG_JEM_MAILER_VENUE_UNPUBLISHED="The Venue is unpublished and needs to be reviewed"
+
+; Submission mailtexts specific of category notifications
+
+PLG_JEM_MAILER_NEW_EVENT_CAT_NOTIFY="There's a new submission from %s ( %s ) \n\nSubmission time: %s \n\nTitle: %s \nDate: %s \nTime: %s \nVenue: %s / %s \n\nDescription:\n%s \n\n%s"
+PLG_JEM_MAILER_EDIT_EVENT_CAT_NOTIFY="An Event was edited from %s ( %s ) \n\nModified at: %s \n\nTitle: %s \nDate: %s \nTime: %s \nVenue: %s / %s \n\nDescription:\n%s \n\n%s"
 
 ; Submission mailtexts for the user
 
@@ -92,6 +109,7 @@ PLG_JEM_MAILER_EDIT_USER_EVENT_MAIL=" %s : Event modification"
 PLG_JEM_MAILER_USER_MAIL_EDIT_EVENT="Hello %s ( %s ), \n\nYou successfully edited the following Event:\nModified at: %s \n\nTitle: %s \nDate: %s \nTime: %s \nVenue: %s / %s \n\nDescription:\n%s \n\n%s"
 PLG_JEM_MAILER_USER_MAIL_EVENT_PUBLISHED="The Event is published and can be viewed by clicking this link: %s"
 PLG_JEM_MAILER_USER_MAIL_EVENT_UNPUBLISHED="Your Event submission will be reviewed and activated soon by an administrator"
+PLG_JEM_MAILER_USER_MAIL_EVENT_TRASHED="You've succesfully deleted the event"
 
 PLG_JEM_MAILER_NEW_USER_VENUE_MAIL=" %s : Thank you for your Venue submission"
 PLG_JEM_MAILER_USER_MAIL_NEW_VENUE="Hello %s ( %s ), \n\nWe successfully received your submission\nWith the details:\nSubmission time: %s \n\nName: %s \nWebsite: %s \nStreet: %s \nZIP: %s \nCity: %s \nCountry: %s \n\nDescription:\n %s \n\n%s"

--- a/plugins/plg_jem_mailer/mailer.xml
+++ b/plugins/plg_jem_mailer/mailer.xml
@@ -18,9 +18,14 @@
 
 	<config>
 		<fields name="params">
-			<fieldset name="basic">
+			<fieldset name="basic" label="PLG_JEM_MAILER_USER_NOTIFICATIONS">
+				
+				<field type="radio"	label="PLG_JEM_MAILER_REGISTRATION"
+					
+				></field>
+				
 				<field type="radio" name="reg_mail_user"
-					label="PLG_JEM_MAILER_USER_REG"
+					label="PLG_JEM_MAILER_USER_LABEL"
 					default="1"
 					description="PLG_JEM_MAILER_USER_REG_DESC"
 				>
@@ -28,15 +33,20 @@
 					<option value="1">JYES</option>
 				</field>
 				<field type="radio" name="reg_mail_admin"
-					label="PLG_JEM_MAILER_ADMIN_REG"
+					label="PLG_JEM_MAILER_ADMIN_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_ADMIN_REG_DESC"
 				>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
+				<field type="spacer"/>
+				
+				<field type="radio"	label="PLG_JEM_MAILER_WAITINGLIST"
+					
+				></field>
 				<field type="radio" name="reg_mail_user_onoff"
-					label="PLG_JEM_MAILER_SETTINGS_USER_REG_ONOFF"
+					label="PLG_JEM_MAILER_USER_LABEL"
 					default="1"
 					description="PLG_JEM_MAILER_SETTINGS_USER_REG_ONOFF_DESC"
 				>
@@ -44,15 +54,20 @@
 					<option value="1">JYES</option>
 				</field>
 				<field type="radio" name="reg_mail_admin_onoff"
-					label="PLG_JEM_MAILER_SETTINGS_ADMIN_REG_ONOFF"
+					label="PLG_JEM_MAILER_ADMIN_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_SETTINGS_ADMIN_REG_ONOFF_DESC"
 				>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
+				<field type="spacer"/>
+				
+				<field type="radio"	label="PLG_JEM_MAILER_UNREGISTRATION"
+					
+				></field>
 				<field type="radio" name="unreg_mail_user"
-					label="PLG_JEM_MAILER_USER_UNREG"
+					label="PLG_JEM_MAILER_USER_LABEL"
 					default="1"
 					description="PLG_JEM_MAILER_USER_UNREG_DESC"
 				>
@@ -60,32 +75,64 @@
 					<option value="1">JYES</option>
 				</field>
 				<field type="radio" name="unreg_mail_admin"
-					label="PLG_JEM_MAILER_ADMIN_UNREG"
+					label="PLG_JEM_MAILER_ADMIN_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_ADMIN_UNREG_DESC"
 				>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
+			</fieldset>
 
-				<field type="radio" name="newevent_mail_user"
-					label="PLG_JEM_MAILER_USER_NEW_EVENT"
-					default="0"
-					description="PLG_JEM_MAILER_USER_NEW_EVENT_DESC"
-				>
-					<option value="0">JNO</option>
-					<option value="1">JYES</option>
-				</field>
+			<fieldset name="event_notifications" label="PLG_JEM_MAILER_EVENT_NOTIFICATIONS">
+				
+					<field type="radio" label="PLG_JEM_MAILER_NEW_EVENT_TITLE">
+					</field>
+					
+					<field type="radio" name="newevent_mail_user"
+						label="PLG_JEM_MAILER_USER_LABEL"
+						default="0"
+						description="PLG_JEM_MAILER_USER_NEW_EVENT_DESC"
+					>
+						<option value="0">JNO</option>
+						<option value="1">JYES</option>
+					</field>
+				
+				
 				<field type="radio" name="newevent_mail_admin"
-					label="PLG_JEM_MAILER_ADMIN_NEW_EVENT"
+					label="PLG_JEM_MAILER_ADMIN_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_ADMIN_NEW_EVENT_DESC"
 				>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
-					<field type="radio" name="editevent_mail_user"
-					label="PLG_JEM_MAILER_USER_EDIT_EVENT"
+				
+				<field type="radio" name="newevent_mail_category"
+					label="PLG_JEM_MAILER_CATEGORY_LABEL"
+					default="0"
+					description="PLG_JEM_MAILER_NOTIFY_CATEGORY_DESC"
+				>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+				
+				<field type="radio" name="newevent_mail_group"
+					label="PLG_JEM_MAILER_GROUP_LABEL"
+					default="0"
+					description="PLG_JEM_MAILER_NEW_EVENT_GROUP"
+				>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+					
+				
+				<field type="spacer"/>
+				<field type="radio" label="PLG_JEM_MAILER_EDIT_EVENT_TITLE">
+				</field>
+				
+				<field type="radio" name="editevent_mail_user"
+					label="PLG_JEM_MAILER_USER_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_USER_EDIT_EVENT_DESC"
 				>
@@ -93,15 +140,50 @@
 					<option value="1">JYES</option>
 				</field>
 				<field type="radio" name="editevent_mail_admin"
-					label="PLG_JEM_MAILER_ADMIN_EDIT_EVENT"
+					label="PLG_JEM_MAILER_ADMIN_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_ADMIN_EDIT_EVENT_DESC"
 				>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
-					<field type="radio" name="newvenue_mail_user"
-					label="PLG_JEM_MAILER_USER_NEW_VENUE"
+				<field type="radio" name="editevent_mail_registered"
+					label="PLG_JEM_MAILER_REGISTERED_EDIT_EVENT"
+					default="0"
+					description="PLG_JEM_MAILER_REGISTERED_EDIT_EVENT_DESC"
+				>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+				
+				<field type="radio" name="editevent_mail_category"
+					label="PLG_JEM_MAILER_CATEGORY_LABEL"
+					default="0"
+					description="PLG_JEM_MAILER_NOTIFY_CATEGORY_DESC"
+				>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+				
+				<field type="radio" name="editevent_mail_group"
+					label="PLG_JEM_MAILER_GROUP_LABEL"
+					default="0"
+					description="PLG_JEM_MAILER_EDIT_EVENT_GROUP"
+				>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+				
+				
+			</fieldset>
+			
+			<fieldset name="venue_notifications" label="PLG_JEM_MAILER_VENUE_NOTIFICATIONS">
+				
+				<field type="radio" label="PLG_JEM_MAILER_NEW_VENUE_TITLE">
+				</field>
+				
+				<field type="radio" name="newvenue_mail_user"
+					label="PLG_JEM_MAILER_USER_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_USER_NEW_VENUE_DESC"
 				>
@@ -109,15 +191,19 @@
 					<option value="1">JYES</option>
 				</field>
 				<field type="radio" name="newvenue_mail_admin"
-					label="PLG_JEM_MAILER_ADMIN_NEW_VENUE"
+					label="PLG_JEM_MAILER_ADMIN_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_ADMIN_NEW_VENUE_DESC"
 				>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
-					<field type="radio" name="editvenue_mail_user"
-					label="PLG_JEM_MAILER_USER_EDIT_VENUE"
+				<field type="spacer"/>
+				
+				<field type="radio" label="PLG_JEM_MAILER_EDIT_VENUE_TITLE">
+				</field>
+				<field type="radio" name="editvenue_mail_user"
+					label="PLG_JEM_MAILER_USER_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_USER_EDIT_VENUE_DESC"
 				>
@@ -125,26 +211,25 @@
 					<option value="1">JYES</option>
 				</field>
 				<field type="radio" name="editvenue_mail_admin"
-					label="PLG_JEM_MAILER_ADMIN_EDIT_VENUE"
+					label="PLG_JEM_MAILER_ADMIN_LABEL"
 					default="0"
 					description="PLG_JEM_MAILER_ADMIN_EDIT_VENUE_DESC"
 				>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
-				<field type="radio" name="fetch_admin_mails"
-					label="PLG_JEM_MAILER_ALL_ADMINS"
-					default="0"
-					description="PLG_JEM_MAILER_ALL_ADMINS_DESC"
-				>
-					<option value="0">JNO</option>
-					<option value="1">JYES</option>
-				</field>
-				<field type="text" name="receivers"
-					label="PLG_JEM_MAILER_ADDITIONAL_MAIL_RECEIVERS"
+			
+			</fieldset>
+			
+
+			<fieldset name="admin_options" label="PLG_JEM_MAILER_ADMIN_OPTIONS">
+
+				<field type="text" name="admin_receivers"
+					label="PLG_JEM_MAILER_ADMIN_MAIL_RECEIVERS"
 					default=""
-					description="PLG_JEM_MAILER_ADDITIONAL_MAIL_RECEIVERS_DESC"
+					description="PLG_JEM_MAILER_ADMIN_MAIL_RECEIVERS_DESC"
 				/>
+
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
This a new version of mailer plugin. Now, JEM can send email notification to several case, in function of
action (new event, update event, delete event, new venue, update venue)
and select type user (owner event, user group, email category,distribution list of plugin):

user group: The users of the group associated with the category of the event.
email category: A mailing list can be assigned to the category to notify new events to a category. In the future this parameter will select list of emails or name from the list of Acymailing (next plugin).
It can notify to registered users of changes in the event (any update, include move to trash (delete).

I have also ready update spanish language file for this new plugin.
I hope you like the changes in this new version of the plugin.
