### PR TITLE
fix frontend editevent popups, privacy (issues #655, #667)

### DIFF
--- a/site/language/en-GB/en-GB.com_jem.ini
+++ b/site/language/en-GB/en-GB.com_jem.ini
@@ -440,6 +440,8 @@ COM_JEM_EDITEVENT_FIELD_DESCRIPTION_DESC="Description"
 COM_JEM_EDITEVENT_WARN_RECURRENCE_TITLE="ATTENTION!"
 COM_JEM_EDITEVENT_WARN_RECURRENCE_TEXT="This event is part of a set of recurring events. If you save this event it will be removed from this set. Even if you just save it without editing at all.<br>If you choose any recurrence in this event a new set of recurring events will be created."
 COM_JEM_EDITEVENT_WARN_RECURRENCE_FIRST_TEXT="This event is the first one of a set of recurring events. If you save this event the set will be dissolved. Even if you just save it without editing at all.<br>If you choose any recurrence in this event a new set of recurring events will be created."
+COM_JEM_NOVENUES="No Venues found."
+COM_JEM_NOCONTACTS="No Contacts found."
 
 ; Search
 COM_JEM_AFRICA="Africa"

--- a/site/models/editevent.php
+++ b/site/models/editevent.php
@@ -230,8 +230,14 @@ class JEMModelEditevent extends JEMModelEvent
 	 */
 	protected function _buildVenuesOrderBy()
 	{
-		$filter_order = JRequest::getCmd('filter_order', 'l.venue');
-		$filter_order_Dir = JRequest::getCmd('filter_order_Dir', 'ASC');
+		$app = JFactory::getApplication();
+
+		$filter_order = $app->getUserStateFromRequest('com_jem.selectvenue.filter_order', 'filter_order', 'l.venue', 'cmd');
+		$filter_order_Dir = $app->getUserStateFromRequest('com_jem.selectvenue.filter_order_Dir', 'filter_order_Dir', 'ASC', 'word');
+
+		$filter_order = JFilterInput::getinstance()->clean($filter_order, 'cmd');
+		$filter_order_Dir = JFilterInput::getinstance()->clean($filter_order_Dir, 'word');
+
 		if (strtoupper($filter_order_Dir) !== 'DESC') {
 			$filter_order_Dir = 'ASC';
 		}
@@ -242,7 +248,7 @@ class JEMModelEditevent extends JEMModelEvent
 			$orderby .= $filter_order . ' ' . $filter_order_Dir . ', ';
 		}
 
-		$orderby .= 'l.ordering';
+		$orderby .= 'l.ordering, l.venue'; // l.ordering seems to be always zero, so use venue as fallback
 
 		return $orderby;
 	}
@@ -332,7 +338,7 @@ class JEMModelEditevent extends JEMModelEvent
 		$filter_order_Dir = JFilterInput::getinstance()->clean($filter_order_Dir, 'word');
 
 		// ensure it's a valid order direction (asc, desc or empty)
-		if (!empty($filter_order_Dir) && strtoupper($filter_order_Dir !== 'DESC')) {
+		if (!empty($filter_order_Dir) && strtoupper($filter_order_Dir) !== 'DESC') {
 			$filter_order_Dir = 'ASC';
 		}
 

--- a/site/views/calendar/tmpl/default.php
+++ b/site/views/calendar/tmpl/default.php
@@ -259,5 +259,10 @@ defined('_JEXEC') or die;
 			?>
 		</div>
 	</div>
+
+	<div class="clr"></div>
+
+	<div class="copyright">
+		<?php echo JemOutput::footer(); ?>
+	</div>
 </div>
-<div class="clr"></div>

--- a/site/views/category/tmpl/calendar.php
+++ b/site/views/category/tmpl/calendar.php
@@ -205,4 +205,8 @@ defined('_JEXEC') or die;
 	// print the calendar
 	echo $this->cal->showMonth();
 	?>
+
+	<div class="copyright">
+		<?php echo JemOutput::footer(); ?>
+	</div>
 </div>

--- a/site/views/editevent/tmpl/choosecontact.php
+++ b/site/views/editevent/tmpl/choosecontact.php
@@ -54,34 +54,46 @@ $function = JRequest::getCmd('function', 'jSelectContact');
 				<tr>
 					<th width="7" class="sectiontableheader"><?php echo JText::_('COM_JEM_NUM'); ?></th>
 					<th align="left" class="sectiontableheader"><?php echo JHtml::_('grid.sort', 'COM_JEM_NAME', 'con.name', $this->lists['order_Dir'], $this->lists['order'] ); ?></th>
-					<th align="left" class="sectiontableheader"><?php echo JHtml::_('grid.sort', 'COM_JEM_ADDRESS', 'con.address', $this->lists['order_Dir'], $this->lists['order'] ); ?></th>
+					<?php if (0) : /* removed because it maybe forbidden to show */ ?>
+						<th align="left" class="sectiontableheader"><?php echo JHtml::_('grid.sort', 'COM_JEM_ADDRESS', 'con.address', $this->lists['order_Dir'], $this->lists['order'] ); ?></th>
+					<?php endif; ?>
 					<th align="left" class="sectiontableheader"><?php echo JHtml::_('grid.sort', 'COM_JEM_CITY', 'con.suburb', $this->lists['order_Dir'], $this->lists['order'] ); ?></th>
 					<th align="left" class="sectiontableheader"><?php echo JHtml::_('grid.sort', 'COM_JEM_STATE', 'con.state', $this->lists['order_Dir'], $this->lists['order'] ); ?></th>
-					<th align="left" class="sectiontableheader"><?php echo JText::_('COM_JEM_EMAIL'); ?></th>
-					<th align="left" class="sectiontableheader"><?php echo JText::_('COM_JEM_TELEPHONE'); ?></th>
-					<th class="title center"><?php echo JText::_('JPUBLISHED'); ?></th>
+					<?php if (0) : /* removed because it maybe forbidden to show */ ?>
+						<th align="left" class="sectiontableheader"><?php echo JText::_('COM_JEM_EMAIL'); ?></th>
+						<th align="left" class="sectiontableheader"><?php echo JText::_('COM_JEM_TELEPHONE'); ?></th>
+					<?php endif; ?>
+					<th width="7" class="title center"><?php echo JText::_('JPUBLISHED'); ?></th>
 				</tr>
 			</thead>
 			<tbody>
-				<?php foreach ($this->rows as $i => $row) : ?>
-				<tr class="row<?php echo $i % 2; ?>">
-					<td class="center"><?php echo $this->pagination->getRowOffset( $i ); ?></td>
-					<td align="left">
-						<span class="editlinktip hasTip" title="<?php echo JText::_('COM_JEM_SELECT');?>::<?php echo $row->name; ?>">
-							<a class="pointer;" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $row->id; ?>', '<?php echo $this->escape(addslashes($row->name)); ?>');"><?php echo $this->escape($row->name); ?></a>
-						</span>
-					</td>
-					<td align="left"><?php echo $this->escape($row->address); ?></td>
-					<td align="left"><?php echo $this->escape($row->suburb); ?></td>
-					<td align="left"><?php echo $this->escape($row->state); ?></td>
-					<td align="left"><?php echo $this->escape($row->email_to); ?></td>
-					<td align="left"><?php echo $this->escape($row->telephone); ?></td>
-					<td class="center">
-						<?php $img = $row->published ? 'tick.png' : 'publish_x.png'; ?>
-						<?php echo JHtml::_('image', 'com_jem/'.$img, NULL, NULL, true); ?>
-					</td>
-				</tr>
-				<?php endforeach; ?>
+				<?php if (empty($this->rows)) : ?>
+					<tr align="center"><td colspan="0"><?php echo JText::_('COM_JEM_NOCONTACTS'); ?></td></tr>
+				<?php else :?>
+					<?php foreach ($this->rows as $i => $row) : ?>
+					<tr class="row<?php echo $i % 2; ?>">
+						<td class="center"><?php echo $this->pagination->getRowOffset( $i ); ?></td>
+						<td align="left">
+							<span class="editlinktip hasTip" title="<?php echo JText::_('COM_JEM_SELECT');?>::<?php echo $row->name; ?>">
+								<a class="pointer;" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $row->id; ?>', '<?php echo $this->escape(addslashes($row->name)); ?>');"><?php echo $this->escape($row->name); ?></a>
+							</span>
+						</td>
+						<?php if (0) : /* removed because it maybe forbidden to show */ ?>
+							<td align="left"><?php echo $this->escape($row->address); ?></td>
+						<?php endif; ?>
+						<td align="left"><?php echo $this->escape($row->suburb); ?></td>
+						<td align="left"><?php echo $this->escape($row->state); ?></td>
+						<?php if (0) : /* removed because it maybe forbidden to show */ ?>
+							<td align="left"><?php echo $this->escape($row->email_to); ?></td>
+							<td align="left"><?php echo $this->escape($row->telephone); ?></td>
+						<?php endif; ?>
+						<td class="center">
+							<?php $img = $row->published ? 'tick.png' : 'publish_x.png'; ?>
+							<?php echo JHtml::_('image', 'com_jem/'.$img, NULL, NULL, true); ?>
+						</td>
+					</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
 			</tbody>
 		</table>
 
@@ -95,9 +107,5 @@ $function = JRequest::getCmd('function', 'jSelectContact');
 
 	<div class="pagination">
 		<?php echo $this->pagination->getPagesLinks(); ?>
-	</div>
-
-	<div class="copyright">
-		<?php echo JemOutput::footer();	?>
 	</div>
 </div>

--- a/site/views/editevent/tmpl/choosevenue.php
+++ b/site/views/editevent/tmpl/choosevenue.php
@@ -29,7 +29,7 @@ $function = JRequest::getCmd('function', 'jSelectVenue');
 
 	<div class="clr"></div>
 
-	<form action="<?php echo JRoute::_('index.php?option=com_jem&view=editevent&layout=choosevenue&tmpl=component&function='.$this->escape($function).'&'.JSession::getFormToken().'=1&filter_order='.$this->lists['order'].'&filter_order_Dir='.$this->lists['order_Dir']); ?>" method="post" name="adminForm" id="adminForm">
+	<form action="<?php echo JRoute::_('index.php?option=com_jem&view=editevent&layout=choosevenue&tmpl=component&function='.$this->escape($function).'&'.JSession::getFormToken().'=1'); ?>" method="post" name="adminForm" id="adminForm">
 		<div id="jem_filter" class="floattext">
 			<div class="jem_fleft">
 				<?php
@@ -60,17 +60,21 @@ $function = JRequest::getCmd('function', 'jSelectVenue');
 				</tr>
 			</thead>
 			<tbody>
-				<?php foreach ($this->rows as $i => $row) : ?>
-				<tr class="row<?php echo $i % 2; ?>">
-				<td><?php echo $this->pagination->getRowOffset( $i ); ?></td>
-				<td align="left">
-					 <a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $row->id; ?>', '<?php echo $this->escape(addslashes($row->venue)); ?>');"><?php echo $this->escape($row->venue); ?></a>
-				</td>
-				<td align="left"><?php echo $this->escape($row->city); ?></td>
-				<td align="left"><?php echo $this->escape($row->state); ?></td>
-				<td align="left"><?php echo $this->escape($row->country); ?></td>
-				</tr>
-				<?php endforeach; ?>
+				<?php if (empty($this->rows)) : ?>
+					<tr align="center"><td colspan="0"><?php echo JText::_('COM_JEM_NOVENUES'); ?></td></tr>
+				<?php else :?>
+					<?php foreach ($this->rows as $i => $row) : ?>
+					<tr class="row<?php echo $i % 2; ?>">
+						<td><?php echo $this->pagination->getRowOffset( $i ); ?></td>
+						<td align="left">
+							<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $row->id; ?>', '<?php echo $this->escape(addslashes($row->venue)); ?>');"><?php echo $this->escape($row->venue); ?></a>
+						</td>
+						<td align="left"><?php echo $this->escape($row->city); ?></td>
+						<td align="left"><?php echo $this->escape($row->state); ?></td>
+						<td align="left"><?php echo $this->escape($row->country); ?></td>
+					</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
 			</tbody>
 		</table>
 
@@ -86,9 +90,5 @@ $function = JRequest::getCmd('function', 'jSelectVenue');
 
 	<div class="pagination">
 		<?php echo $this->pagination->getPagesLinks(); ?>
-	</div>
-
-	<div class="copyright">
-		<?php echo JemOutput::footer();	?>
 	</div>
 </div>

--- a/site/views/editevent/tmpl/edit.php
+++ b/site/views/editevent/tmpl/edit.php
@@ -194,4 +194,8 @@ $settings	= json_decode($this->item->attribs);
 			<?php echo JHtml::_('form.token'); ?>
 		</form>
 	</div>
+
+	<div class="copyright">
+		<?php echo JemOutput::footer(); ?>
+	</div>
 </div>

--- a/site/views/editevent/view.html.php
+++ b/site/views/editevent/view.html.php
@@ -226,20 +226,23 @@ class JemViewEditevent extends JViewLegacy
 	 */
 	protected function _displaychoosevenue($tpl)
 	{
-		$app			= JFactory::getApplication();
-		$jemsettings = JemHelper::config();
-		$document    = JFactory::getDocument();
+		$app         = JFactory::getApplication();
 		$jinput      = JFactory::getApplication()->input;
-		$limitstart  = $jinput->get('limitstart', '0', 'int');
-		$limit       = $app->getUserStateFromRequest('com_jem.selectvenue.limit', 'limit', $jemsettings->display_num, 'int');
+		$jemsettings = JemHelper::config();
+		$db          = JFactory::getDBO();
+		$document    = JFactory::getDocument();
 
-		$filter_order 		= $jinput->get('filter_order', 'l.venue', 'cmd');
-		$filter_order_Dir	= $jinput->get('filter_order_Dir', 'ASC', 'word');
-		$filter				= $jinput->get('filter_search', '', 'string');
-		$filter_type		= $jinput->get('filter_type', '', 'int');
+		$filter_order     = $app->getUserStateFromRequest('com_jem.selectvenue.filter_order', 'filter_order', 'l.venue', 'cmd');
+		$filter_order_Dir = $app->getUserStateFromRequest('com_jem.selectvenue.filter_order_Dir', 'filter_order_Dir', 'ASC', 'word');
+		$filter           = $app->getUserStateFromRequest('com_jem.selectvenue.filter', 'filter', '', 'int');
+		$filter_state     = $app->getUserStateFromRequest('com_jem.selectvenue.filter_state', 'filter_state', '*', 'word');
+		$search           = $app->getUserStateFromRequest('com_jem.selectvenue.filter_search', 'filter_search', '', 'string');
+		$search           = $db->escape(trim(JString::strtolower($search)));
+		$limitstart       = $jinput->get('limitstart', '0', 'int');
+		$limit            = $app->getUserStateFromRequest('com_jem.selectvenue.limit', 'limit', $jemsettings->display_num, 'int');
 
 		// Get/Create the model
-		$rows = $this->get('Venues');
+		$rows  = $this->get('Venues');
 		$total = $this->get('Countitems');
 
 		JHtml::_('behavior.modal', 'a.flyermodal');
@@ -248,9 +251,12 @@ class JemViewEditevent extends JViewLegacy
 		jimport('joomla.html.pagination');
 		$pagination = new JPagination($total, $limitstart, $limit);
 
+		//publish unpublished filter
+		$lists['state'] = JHtml::_('grid.state', $filter_state);
+
 		// table ordering
 		$lists['order_Dir'] = $filter_order_Dir;
-		$lists['order']		= $filter_order;
+		$lists['order']     = $filter_order;
 
 		$document->setTitle(JText::_('COM_JEM_SELECT_VENUE'));
 		JHtml::_('stylesheet', 'com_jem/jem.css', array(), true);
@@ -259,13 +265,13 @@ class JemViewEditevent extends JViewLegacy
 		$filters[] = JHtml::_('select.option', '1', JText::_('COM_JEM_VENUE'));
 		$filters[] = JHtml::_('select.option', '2', JText::_('COM_JEM_CITY'));
 		$filters[] = JHtml::_('select.option', '3', JText::_('COM_JEM_STATE'));
-		$searchfilter = JHtml::_('select.genericlist', $filters, 'filter_type', 'size="1" class="inputbox"', 'value', 'text', $filter_type);
+		$searchfilter = JHtml::_('select.genericlist', $filters, 'filter_type', 'size="1" class="inputbox"', 'value', 'text', $filter);
 
-		$this->rows = $rows;
+		$this->rows         = $rows;
 		$this->searchfilter = $searchfilter;
-		$this->pagination = $pagination;
-		$this->lists = $lists;
-		$this->filter = $filter;
+		$this->pagination   = $pagination;
+		$this->lists        = $lists;
+		$this->filter       = $search;
 
 		parent::display($tpl);
 	}
@@ -282,14 +288,14 @@ class JemViewEditevent extends JViewLegacy
 		$db          = JFactory::getDBO();
 		$document    = JFactory::getDocument();
 
-		$filter_order		= $app->getUserStateFromRequest('com_jem.contactelement.filter_order', 'filter_order', 'con.name', 'cmd');
-		$filter_order_Dir	= $app->getUserStateFromRequest('com_jem.contactelement.filter_order_Dir', 'filter_order_Dir', '', 'word');
-		$filter 			= $app->getUserStateFromRequest('com_jem.contactelement.filter', 'filter', '', 'int');
-		$filter_state 		= $app->getUserStateFromRequest('com_jem.contactelement.filter_state', 'filter_state', '*', 'word');
-		$search 			= $app->getUserStateFromRequest('com_jem.contactelement.filter_search', 'filter_search', '', 'string');
-		$search 			= $db->escape(trim(JString::strtolower($search)));
-		$limitstart 		= $jinput->get('limitstart', '0', 'int');
-		$limit				= $app->getUserStateFromRequest('com_jem.selectcontact.limit', 'limit', $jemsettings->display_num, 'int');
+		$filter_order     = $app->getUserStateFromRequest('com_jem.selectcontact.filter_order', 'filter_order', 'con.name', 'cmd');
+		$filter_order_Dir = $app->getUserStateFromRequest('com_jem.selectcontact.filter_order_Dir', 'filter_order_Dir', '', 'word');
+		$filter           = $app->getUserStateFromRequest('com_jem.selectcontact.filter', 'filter', '', 'int');
+		$filter_state     = $app->getUserStateFromRequest('com_jem.selectcontact.filter_state', 'filter_state', '*', 'word');
+		$search           = $app->getUserStateFromRequest('com_jem.selectcontact.filter_search', 'filter_search', '', 'string');
+		$search           = $db->escape(trim(JString::strtolower($search)));
+		$limitstart       = $jinput->get('limitstart', '0', 'int');
+		$limit            = $app->getUserStateFromRequest('com_jem.selectcontact.limit', 'limit', $jemsettings->display_num, 'int');
 
 		JHtml::_('behavior.tooltip');
 		JHtml::_('behavior.modal', 'a.flyermodal');
@@ -300,8 +306,8 @@ class JemViewEditevent extends JViewLegacy
 		$document->setTitle(JText::_('COM_JEM_SELECT_CONTACT'));
 
 		// Get/Create the model
-		$rows	= $this->get('Contact');
-		$total	= $this->get('CountContactitems');
+		$rows  = $this->get('Contact');
+		$total = $this->get('CountContactitems');
 
 		// Create the pagination object
 		jimport('joomla.html.pagination');
@@ -312,12 +318,12 @@ class JemViewEditevent extends JViewLegacy
 
 		// table ordering
 		$lists['order_Dir'] = $filter_order_Dir;
-		$lists['order']		= $filter_order;
+		$lists['order']     = $filter_order;
 
 		//Build search filter
 		$filters = array();
 		$filters[] = JHtml::_('select.option', '1', JText::_('COM_JEM_NAME'));
-		$filters[] = JHtml::_('select.option', '2', JText::_('COM_JEM_ADDRESS'));
+	/*	$filters[] = JHtml::_('select.option', '2', JText::_('COM_JEM_ADDRESS')); */ // data security
 		$filters[] = JHtml::_('select.option', '3', JText::_('COM_JEM_CITY'));
 		$filters[] = JHtml::_('select.option', '4', JText::_('COM_JEM_STATE'));
 		$searchfilter = JHtml::_('select.genericlist', $filters, 'filter', 'size="1" class="inputbox"', 'value', 'text', $filter);
@@ -327,9 +333,9 @@ class JemViewEditevent extends JViewLegacy
 
 		//assign data to template
 		$this->searchfilter = $searchfilter;
-		$this->lists		= $lists;
-		$this->rows			= $rows;
-		$this->pagination	= $pagination;
+		$this->lists        = $lists;
+		$this->rows         = $rows;
+		$this->pagination   = $pagination;
 
 		parent::display($tpl);
 	}

--- a/site/views/editvenue/tmpl/edit.php
+++ b/site/views/editvenue/tmpl/edit.php
@@ -273,4 +273,8 @@ $options = array(
 			<?php echo JHtml::_('form.token'); ?>
 		</form>
 	</div>
+
+	<div class="copyright">
+		<?php echo JemOutput::footer(); ?>
+	</div>
 </div>

--- a/site/views/venue/tmpl/calendar.php
+++ b/site/views/venue/tmpl/calendar.php
@@ -265,5 +265,10 @@ defined('_JEXEC') or die;
 			?>
 		</div>
 	</div>
+
+	<div class="clr"></div>
+
+	<div class="copyright">
+		<?php echo JemOutput::footer(); ?>
+	</div>
 </div>
-<div class="clr"></div>

--- a/site/views/weekcal/tmpl/default.php
+++ b/site/views/weekcal/tmpl/default.php
@@ -259,5 +259,10 @@ defined('_JEXEC') or die;
 			?>
 		</div>
 	</div>
+
+	<div class="clr"></div>
+
+	<div class="copyright">
+		<?php echo JemOutput::footer(); ?>
+	</div>
 </div>
-<div class="clr"></div>


### PR DESCRIPTION
- sorting, filtering, limitation fixed in venues and contacts popups
- email, address, phone number removed from contacts popup
- useful second level sort criteria (e.g. name)
- "Powered by" shown on all non-popup views, but only there
