### PR TITLE
Fix #1097 add google API key for geocomplete.js

### DIFF
--- a/admin/views/venue/view.html.php
+++ b/admin/views/venue/view.html.php
@@ -55,7 +55,8 @@ class JemViewVenue extends JemAdminView
 		$language = $language->getTag();
 		$language = substr($language, 0,2);
 
-		$document->addScript('http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places&language='.$language);
+        $key = trim($this->settings->globalattribs->global_googleapi);
+        $document->addScript('http://maps.googleapis.com/maps/api/js?'.(!empty($key) ? 'key='.$key.'&amp;' : '').'sensor=false&amp;libraries=places&language='.$language);
 
 		// Noconflict
 		$document->addCustomTag('<script type="text/javascript">jQuery.noConflict();</script>');

--- a/site/helpers/helper.php
+++ b/site/helpers/helper.php
@@ -19,7 +19,6 @@ require_once(JPATH_SITE.'/components/com_jem/factory.php');
  */
 class JemHelper
 {
-
 	/**
 	 * Pulls settings from database and stores in an static object
 	 *
@@ -801,7 +800,6 @@ class JemHelper
 			$query = ' UPDATE #__jem_register SET waiting = 0 WHERE id IN ('.implode(',', $bumping).')';
 			$db->setQuery($query);
 			if ($db->execute() === false) {
-				$this->setError(JText::_('COM_JEM_FAILED_BUMPING_USERS_FROM_WAITING_TO_CONFIRMED_LIST'));
 				Jerror::raisewarning(0, JText::_('COM_JEM_FAILED_BUMPING_USERS_FROM_WAITING_TO_CONFIRMED_LIST').': '.$db->getErrorMsg());
 			} else {
 				foreach ($bumping AS $register_id)

--- a/site/views/editvenue/view.html.php
+++ b/site/views/editvenue/view.html.php
@@ -152,7 +152,8 @@ class JemViewEditvenue extends JViewLegacy
 		// Load script
 		JHtml::_('script', 'com_jem/attachments.js', false, true);
 		JHtml::_('script', 'com_jem/other.js', false, true);
-		$document->addScript('http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=places&language='.$language);
+		$key = trim($jemsettings->globalattribs->global_googleapi);
+		$document->addScript('http://maps.googleapis.com/maps/api/js?'.(!empty($key) ? 'key='.$key.'&amp;' : '').'sensor=false&amp;libraries=places&language='.$language);
 
 		// Noconflict
 		$document->addCustomTag( '<script type="text/javascript">jQuery.noConflict();</script>' );


### PR DESCRIPTION
The API Key for google Maps is required for new sites since 22th july. Old sites work without the API key, but for sites using the API after that date the Key is required. So I added it to the geocomplete calls.