### PR TITLE
Fixed edit venue check-out bug

### DIFF
--- a/site/classes/output.class.php
+++ b/site/classes/output.class.php
@@ -468,7 +468,7 @@ static public function lightbox() {
 
 				case 'editvenue':
 					if (property_exists($item, 'vChecked_out') && property_exists($item, 'vChecked_out_time') && $item->vChecked_out > 0 && $item->vChecked_out != $userId) {
-						$checkoutUser = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($item->checked_out);
+						$checkoutUser = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($item->vChecked_out);
 						$button = HTMLHelper::_('image', 'system/checked_out.png', NULL, NULL, true);
 						$date = HTMLHelper::_('date', $item->vChecked_out_time);
 						return '<span ' . self::tooltip(Text::_('JLIB_HTML_CHECKED_OUT'), htmlspecialchars(Text::sprintf('COM_JEM_GLOBAL_CHECKED_OUT_BY', $checkoutUser->name) . ' <br /> ' . $date, ENT_COMPAT, 'UTF-8')) . '>' . $button . '</span>';


### PR DESCRIPTION
A user of our website reported seeing the following error message when viewing a page powered by JEM:

> Error 0
Joomla\CMS\User\UserFactory::loadUserById(): Argument 1 ($id) must be of type int, null given, called in /.../components/com_jem/classes/output.class.php on line 470

I could not reproduce the error, but it seemed to be fixed after running the global check-in task in the back-end. Looking at the referenced line of code, I spotted that perhaps `$item->checked_out` should in fact be `$item->vChecked_out`, as the latter is checked in the enclosing conditional. 