### PR TITLE
minor improvements

### DIFF
--- a/site/classes/calendar.class.php
+++ b/site/classes/calendar.class.php
@@ -175,10 +175,10 @@ class JemCalendar
 
         if (version_compare(JVERSION, '5.0.0', '>=')) {
             // Joomla 5
-            $this->yearNavBack=" <i class='fa-solid fa-backward'></i> "; // Previous year
-            $this->yearNavForw=" <i class='fa-solid fa-forward'></i> "; // Next year
-            $this->monthNavBack=" <i class='fa-solid fa-backward-step'></i> "; // Previous month
-            $this->monthNavForw=" <i class='fa-solid fa-forward-step'></i> "; // Next month
+            $this->yearNavBack=" <i class='fa-solid fa-angles-left'></i> "; // Previous year
+            $this->yearNavForw=" <i class='fa-solid fa-angles-right'></i> "; // Next year
+            $this->monthNavBack=" <i class='fa-solid fa-angle-left'></i> "; // Previous month
+            $this->monthNavForw=" <i class='fa-solid fa-angle-right'></i> "; // Next month
         } elseif (version_compare(JVERSION, '4.0.0', '>=')) {
             // Joomla 4
             $this->yearNavBack=" &lt;&lt; "; // Previous year, this could be an image link
@@ -694,7 +694,7 @@ class JemCalendar
             if (($this->getWeekday($var) == 6) && $this->crSatClass) {
                 $cssClass[] = $this->cssSaturday;
             }
-            $out = "<td class=\"".implode(' ', $cssClass)."\"><div class=\"daynum\" jem-monthname=\"".$this->getMonthName()."\" jem-dayname=\"".$this->getDayName($this->getWeekday($var))."\">".$htmlNewEventLink.$linktext.'</div>'.$eventContent."</td>";
+            $out = "<td class=\"".implode(' ', $cssClass)."\"><div class=\"daynum\" jem-monthname=\"".$this->getMonthName()."\" jem-dayname=\"".$this->getDayName($this->getWeekday($var))."\">".$htmlNewEventLink.'<span>'.$linktext.'</span></div>'.$eventContent."</td>";
         }
 
         return $out;


### PR DESCRIPTION
1. Use more elegant and distinctive icons in the calendar view. The current ones belong to the video player icon category.

Before:
<img width="1179" height="153" alt="old-iconstyle" src="https://github.com/user-attachments/assets/70097d62-2b3d-4243-b0ec-069d9956a830" />

After:
<img width="1183" height="152" alt="new-iconstyle" src="https://github.com/user-attachments/assets/a178c7db-4a9c-4520-a9df-5a6d2772eab9" />


2. Add a `span` element to uniquely style the tag using CSS. In edit mode, it was not possible to target the day display directly.

After:
<img width="176" height="217" alt="daynum-span" src="https://github.com/user-attachments/assets/f1f8ea51-255f-45fa-be7a-3c4309b09874" />
