### PR TITLE
minor improvment part 2

### DIFF
--- a/site/classes/calendar.class.php
+++ b/site/classes/calendar.class.php
@@ -694,6 +694,9 @@ class JemCalendar
             if (($this->getWeekday($var) == 6) && $this->crSatClass) {
                 $cssClass[] = $this->cssSaturday;
             }
+            if ($eventContent) {
+                $cssClass[] = 'busy';
+            }
             $out = "<td class=\"".implode(' ', $cssClass)."\"><div class=\"daynum\" jem-monthname=\"".$this->getMonthName()."\" jem-dayname=\"".$this->getDayName($this->getWeekday($var))."\">".$htmlNewEventLink.'<span>'.$linktext.'</span></div>'.$eventContent."</td>";
         }
 


### PR DESCRIPTION
Add the “busy” css class to all <td> elements that contain at least one event. This allows for better styling. Our goal is to display only days with events in the responsive view for greater clarity (see screenshot).

The CSS style for this is:
.monthday:not(.busy) {
  display: none !important;
}


<img width="750" height="1334" alt="rsponsive-layout" src="https://github.com/user-attachments/assets/5add807d-4545-4fc8-b060-5e2bb699367d" />
