### PR TITLE
Change breakpoint for responsive calendar view

### DIFF
--- a/media/css/calendar-responsive.css
+++ b/media/css/calendar-responsive.css
@@ -473,7 +473,7 @@ div#jem .monthname { /*delete complete construct */
 
 
 @media not print {
-    @media only all and (max-width: 30rem), screen and (max-device-width: 30rem) and (orientation: landscape) {
+    @media only all and (max-width: 48rem), screen and (max-device-width: 48rem) and (orientation: landscape) {
         /* Force table to not be like tables anymore */
         div#jem table, div#jem thead, div#jem tbody, div#jem th, div#jem td, div#jem tr {
             display: inline;


### PR DESCRIPTION
This pull request increases the breakpoint value for the monthly calendar view and improves readability. 48rem (768px) is a common value for the monthly view.

The screenshot shows the calendar with 30rem on the left and 48rem on the right:

<img width="1950" height="1050" alt="view-30-48-rem" src="https://github.com/user-attachments/assets/69864d24-f5dc-4149-a2e9-9b47e61140df" />
